### PR TITLE
Improve PHPUnit fixtures and add php-7.4 version

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,4 +5,3 @@ enabled:
 
 disabled:
   - concat_without_spaces
-  - self_accessor

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 env:
   matrix:

--- a/tests/NullDriverTest.php
+++ b/tests/NullDriverTest.php
@@ -39,7 +39,7 @@ class NullDriverTest extends TestCase
         ]);
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         Mockery::close();
     }


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit fixtures doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be `protected function tearDown(): void`.
- Adding the `php-7.4` version during Travis CI build.
- Remove the `self_accessor` fixer because of the `The 'self_accessor' fixer cannot be disabled because it is not enabled by your preset.` message.